### PR TITLE
multiple updates

### DIFF
--- a/lib/directory-tree.js
+++ b/lib/directory-tree.js
@@ -1,54 +1,22 @@
-var fs = require('fs');
-var path = require('path');
+const FS = require('fs');
+const PATH = require('path');
 
-function directoryTree(basepath, extensions) {
-    var _directoryTree = function (name, extensions) {
-        /*
-         * Certain symbolic links/weird files break when you try to stat them
-         */
-        try {
-            var stats = fs.statSync(name);
-        } catch(e) {
-            return null;
-        }
+function directoryTree (path, extensions) {
+    const stats = FS.statSync(path);
+    const name = PATH.basename(path);
+    const item = { path, name };
 
-        var item = {
-            path: path.relative(basepath, name),
-            name: path.basename(name)
-        };
-
-        if (stats.isFile()) {
-            if (extensions &&
-                extensions.length > 0 &&
-                extensions.indexOf(path.extname(name).toLowerCase()) == -1 &&
-                extensions.indexOf(path.basename(name)) > -1) {
-                return null;
-            }
-            item.type = 'file';
-            item.size = stats.size;  // File size in bytes
-        } else if(stats.isDirectory()) {
-            item.type = 'directory';
-            item.children = fs.readdirSync(name).map(function (child) {
-                return _directoryTree(path.join(name, child), extensions);
-            }).filter(function (e) {
-                return e != null;
-            });
-
-            if (item.children.length == 0) {
-                return null;
-            } else { // The dir has files inside of it, sum up their size
-                item.size = item.children.reduce(function(previous, current) {
-                    return previous + current.size;
-                }, 0);
-            }
-        } else {
-            return null;
-        }
-
-        return item;
+    if (stats.isFile()) {
+        const ext = PATH.extname(path).toLowerCase();
+        if (extensions && extensions.length && extensions.indexOf(ext) === -1) return null;
     }
-    return _directoryTree(basepath, extensions);
+    else {
+        item.children = FS.readdirSync(path)
+            .map(child => directoryTree(PATH.join(path, child), extensions))
+            .filter(e => !!e);
+        if (!item.children.length) return null;
+    }
+    return item;
 }
 
 exports.directoryTree = directoryTree;
-


### PR DESCRIPTION
- simplify code; 
- some es6; 
- return full path instead of relative (IMO this was a bug, as the relative path is useless, cannot get file info in a nice reactive way, etc.)
- remove `item.type` as it's redundant information (`item.type = (item.children ? 'directory' : 'file')`)
